### PR TITLE
Fix censys dependency to <1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tweepy
 passivetotal
 beautifulsoup4==4.9.1
 lxml==4.5.1
-censys
+censys<1.0.0
 shodan
 fullcontact.py
 pyhunter

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'passivetotal',
         'beautifulsoup4==4.9.1',
         'lxml==4.5.1',
-        'censys',
+        'censys<1.0.0',
         'shodan',
         'fullcontact.py',
         'pyhunter',


### PR DESCRIPTION
the query interface was removed in this version (censys/censys-python#23), which is imported in `harpoon/commands/censyscmd.py`

### steps to reproduce
```
# setup  and activate venv
$ python -m virtualenv venv
$ source venv/bin/activate

# install harpoon and start
$ pip install .
$ python harpoon/main.py 
Traceback (most recent call last):
  File "harpoon/main.py", line 66, in <module>
    main()
  File "harpoon/main.py", line 40, in main
    plugins = init_plugins()
  File "harpoon/main.py", line 26, in init_plugins
    mod = __import__(plugin)
  File "[...]/harpoon/harpoon/commands/censyscmd.py", line 5, in <module>
    from censys import ipv4, certificates, query
ImportError: cannot import name 'query' from 'censys' ([...]/harpoon/venv/lib/python3.8/site-packages/censys/__init__.py)
