### PR TITLE
Creating UrlHaus plugin #125

### DIFF
--- a/harpoon/commands/censyscmd.py
+++ b/harpoon/commands/censyscmd.py
@@ -2,7 +2,7 @@
 import sys
 import json
 import censys
-from censys import ipv4, certificates, query
+from censys import ipv4, certificates
 from harpoon.commands.base import Command
 
 
@@ -35,6 +35,8 @@ class CommandCensys(Command):
         parser_c.add_argument('--verbose', '-v', action='store_true',
                 help='Verbose')
         parser_c.set_defaults(subcommand='subdomains')
+        parser_d = subparsers.add_parser('account', help='Get account information including quota')
+        parser_d.set_defaults(subcommand='account')
         self.parser = parser
 
     def get_subdomains(self, conf, domain, verbose, only_sub=False):
@@ -104,6 +106,11 @@ class CommandCensys(Command):
                 subdomains = self.get_subdomains(conf, args.DOMAIN, args.verbose)
                 for d in subdomains:
                     print(d)
+            elif args.subcommand == 'account':
+                api = ipv4.CensysIPv4(conf['Censys']['id'], conf['Censys']['secret'])
+                # Gets account data
+                account = api.account()
+                print(json.dumps(account, sort_keys=True, indent=4))
             else:
                 self.parser.print_help()
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ tweepy
 passivetotal
 beautifulsoup4==4.9.1
 lxml==4.5.1
-censys<1.0.0
+censys==1.0.0
 shodan
 fullcontact.py
 pyhunter

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'passivetotal',
         'beautifulsoup4==4.9.1',
         'lxml==4.5.1',
-        'censys<1.0.0',
+        'censys==1.0.0',
         'shodan',
         'fullcontact.py',
         'pyhunter',


### PR DESCRIPTION
This work implements the enrichment section of the urlhaus.abuse.ch API. It doesn't implement submissions but allow user to query url, hostnames tags and samples.

Example usages:
```
harpoon urlhaus get-url http://perdu.com
harpoon urlhaus get-host perdu.com
harpoon urlhaus get-tag gozi
harpoon urlhaus get-signature 5d41402abc4b2a76b9719d911017c592
harpoon urlhaus get-sample 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
```

This work opens a new configuration too for this API although it isn't need for the current implementation.

```
[UrlHaus]
key:Your_api_key
```

Queries and bug reports welcomed!