### PR TITLE
Add MaxMind path check for macOS (brew)

### DIFF
--- a/harpoon/commands/ip.py
+++ b/harpoon/commands/ip.py
@@ -123,11 +123,14 @@ class CommandIp(Command):
         Depending on geoipupdate version it can be stored in:
         /usr/share/GeoIP/
         /var/lib/GeoIP
+        /usr/local/var/GeoIP/
         """
         if os.path.isfile("/usr/share/GeoIP/GeoLite2-City.mmdb"):
             self.geocity = "/usr/share/GeoIP/GeoLite2-City.mmdb"
         elif os.path.isfile("/var/lib/GeoIP/GeoLite2-City.mmdb"):
             self.geocity = "/var/lib/GeoIP/GeoLite2-City.mmdb"
+        elif os.path.isfile("/usr/local/var/GeoIP/GeoLite2-City.mmdb"):
+            self.geocity = "/usr/local/var/GeoIP/GeoLite2-City.mmdb"
         else:
             print("Impossible to find GeoIP db")
             print("Make sure you have geoipupdate correctly configured")
@@ -137,6 +140,8 @@ class CommandIp(Command):
             self.geoasn = "/usr/share/GeoIP/GeoLite2-ASN.mmdb"
         elif os.path.isfile("/var/lib/GeoIP/GeoLite2-ASN.mmdb"):
             self.geoasn = "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
+        elif os.path.isfile("/usr/local/var/GeoIP/GeoLite2-ASN.mmdb"):
+            self.geoasn = "/usr/local/var/GeoIP/GeoLite2-ASN.mmdb"
         else:
             print("Impossible to find GeoIP ASN db")
             print("Make sure you have geoipupdate correctly configured")


### PR DESCRIPTION
Thank you for this awesome tool :thumbsup:

## Description
If the MaxMind GeoIP database is installed on macOS via Brew, the correct path is not checked in `check_geoipdb`.
I added the path to the check.

## Has This Been Tested?
Yes, on macOS Catalina (10.15.7) and brew 2.6.0.