### PR TITLE
Fixing a typo error in Greynoise config

### DIFF
--- a/harpoon/data/example.conf
+++ b/harpoon/data/example.conf
@@ -118,7 +118,7 @@ intel: true
 key:
 password:
 
-[Greynoise]
+[GreyNoise]
 key:
 intel: true
 


### PR DESCRIPTION
Changed the config `Greynoise` to `GreyNoise` to match the code, it was breaking on a clean install. 